### PR TITLE
Add CircleCI config for building K8 on Linux ARM64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,47 @@
+version: 2.1
+
+jobs:
+  build-aarch64:
+    
+    machine:
+      image: ubuntu-2204:current
+    resource_class: arm.large
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install dependencies
+          command: |
+            sudo apt update
+            sudo apt-get install -y file tar wget make
+
+      - run:
+          name: Build K8 Linux ARM64 binary
+          environment:
+            NODE_VERSION: 18.18.1
+          command: |
+            # Hack CircleCI Ubuntu Docker image to link 'python' to 'python3'
+            echo -e '#!/usr/bin/env bash\n\nexport PYENV_ROOT="/opt/circleci/.pyenv"\nexec "/opt/circleci/.pyenv/libexec/pyenv" exec "python3" "$@"' > ~/bin/python
+            chmod +x ~/bin/python
+            PATH=~/bin:$PATH
+            python --version
+
+            wget -O- https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.gz | tar -zxf -
+            pushd node-v${NODE_VERSION}
+            ./configure
+            make -j3
+            popd
+
+            # Then compile k8
+            NODE_SRC=node-v${NODE_VERSION} make -j
+            file k8 | grep aarch64
+            mv k8 k8-aarch64-Linux
+      
+      - store_artifacts:
+          path: k8-aarch64-Linux
+
+workflows:
+  build:
+    jobs:
+      - build-aarch64

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXXFLAGS=-std=c++17 -g -O3 -Wall
-NODE_SRC=..
+NODE_SRC?=..
 EXE=k8
 LIB_COMMON=-lv8_snapshot -lv8_libplatform -lv8_base_without_compiler -lv8_libbase -lv8_zlib -lv8_compiler -licutools -lm -ldl -lz
 LIB_LINUX=-L$(NODE_SRC)/out/Release -L$(NODE_SRC)/out/Release/obj.target/tools/v8_gypfiles -L$(NODE_SRC)/out/Release/obj.target/tools/icu \


### PR DESCRIPTION
Fixes #9

This CircleCI config has two purposes:

1) act as a CI check for any changes in the source code. At the moment it builds `k8` only on Linux ARM64 but it could be extended to Linux x86_64, Mac and Windows, if desired !
**Note**: currently the workflow does not use [caching](https://circleci.com/docs/caching/) ! The build of Node.js takes almost 40mins and its results could be cached! But the cache should be invalidated when building against a newer version of Node.js! Please let me know if you want me to add it!

2) to provide a Linux aarch64 binary for releases. A successful build stores the binary in the workflow [Artifacts](https://circleci.com/docs/artifacts/#artifacts-overview). The release manager can download manually the binary and add it to the release bundle.